### PR TITLE
Remove `c-bar-label` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `.c-message--note` and `.c-message--dark` have been renamed
 
+### Removed
+- `c-bar-label` has been removed
+
 ## [0.0.1-alpha.0] - 2019-12-02
 
 ### Added

--- a/dist/design-system.css
+++ b/dist/design-system.css
@@ -719,12 +719,6 @@ a {
   background-color: #D1E1F8;
 }
 
-.c-bar-label {
-  line-height: 1;
-  margin-bottom: 0.75rem;
-  display: block;
-}
-
 .c-box {
   box-shadow: 0 1px 3px 0 rgba(10,21,48, .1), 0 1px 2px 0 rgba(10,21,48, .06);
   border-radius: 0.25rem;

--- a/src/components/bar.css
+++ b/src/components/bar.css
@@ -1,7 +1,3 @@
 .c-bar {
   @apply h-2 rounded-full bg-blue-100;
 }
-
-.c-bar-label {
-  @apply leading-none mb-3 block;
-}


### PR DESCRIPTION
The `c-bar-label` class has been a bit of a weird one from the start,
since it can't really live without the `c-bar` class, but also doesn't
live as a child of this one. Since the only important class on this one
is the `mb-3` I feel it makes sense to no longer use it.