### PR TITLE
Remove text color link

### DIFF
--- a/dist/design-system.css
+++ b/dist/design-system.css
@@ -635,7 +635,6 @@ html {
 
 a {
   text-decoration: underline;
-  /* color: theme("colors.blue.400") */
 }
 
 @font-face {

--- a/src/defaults/all.css
+++ b/src/defaults/all.css
@@ -5,5 +5,4 @@ html {
 
 a {
   text-decoration: underline;
-  /* color: theme("colors.blue.400") */
 }


### PR DESCRIPTION
We had the text color as commented css, which somehow chrome tries to
render still.